### PR TITLE
feat(proxy): Forward requests via JSON RPC endpoint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,48 +1,49 @@
-name: Release
+# This workflow is modified from Reth:
+# https://github.com/paradigmxyz/reth/blob/main/.github/workflows/release.yml
+
+name: release
 
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     tags:
-      - 'v*'
-
-permissions:
-  contents: write
+      - v*
 
 env:
-  REGISTRY_IMAGE: flashbots/rollup-boost
+  IMAGE_NAME: ${{ github.repository }}
+  CARGO_TERM_COLOR: always
+  REGISTRY: ghcr.io
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
-  build:
-    name: Publish Docker Image
-    strategy:
-      matrix:
-        config:
-          - platform: linux/amd64
-            runner: warp-ubuntu-latest-x64-16x
-          - platform: linux/arm64
-            runner: warp-ubuntu-latest-arm64-16x
-    runs-on: ${{ matrix.config.runner }}
+  build-and-push:
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
+      - name: Check Out Repo
+        uses: actions/checkout@v4
 
-      - name: Set env
-        run: |
-          platform=${{ matrix.config.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-
-      - name: Print version
-        run: |
-          echo $RELEASE_VERSION
-          echo ${{ env.RELEASE_VERSION }}
-
-      - name: Extract metadata (tags, labels) for Docker images
-        id: meta
-        uses: docker/metadata-action@v4
+      - name: Log in to Registry
+        uses: docker/login-action@v3
         with:
-          images: ${{ env.REGISTRY_IMAGE }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha
+            type=raw,value=latest
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -50,94 +51,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.FLASHBOTS_DOCKERHUB_USERNAME }}
-          password: ${{ secrets.FLASHBOTS_DOCKERHUB_TOKEN }}
-
       - name: Build and push
-        id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v5
         with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          annotations: ${{ steps.meta.outputs.annotations }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          context: .
-          build-args: |
-            VERSION=${{ env.RELEASE_VERSION }}
-          platforms: ${{ matrix.config.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ env.PLATFORM_PAIR }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge:
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.FLASHBOTS_DOCKERHUB_USERNAME }}
-          password: ${{ secrets.FLASHBOTS_DOCKERHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY_IMAGE }}
-          tags: |
-            type=sha
-            type=pep440,pattern={{version}}
-            type=pep440,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ !contains(env.RELEASE_VERSION, '-') }}
-
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
-
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
-
-  github-release:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Create release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: true
-          prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,3 @@
-# This workflow is modified from Reth:
-# https://github.com/paradigmxyz/reth/blob/main/.github/workflows/release.yml
-
 name: release
 
 on:

--- a/src/integration/service_rb.rs
+++ b/src/integration/service_rb.rs
@@ -41,13 +41,17 @@ impl Service for RollupBoostConfig {
         let jwt_path = self.jwt_path.as_ref().expect("jwt_path not set");
 
         let cmd = ServiceCommand::new(bin_path.to_str().unwrap())
-            .arg("--l2-jwt-path")
+            .arg("--l2-auth-jwt-path")
             .arg(jwt_path.clone())
-            .arg("--builder-jwt-path")
+            .arg("--builder-auth-jwt-path")
             .arg(jwt_path.clone())
-            .arg("--l2-url")
+            .arg("--l2-auth-url")
             .arg(self.l2_url.as_ref().expect("l2_url not set"))
-            .arg("--builder-url")
+            .arg("--l2-http-url")
+            .arg(self.l2_url.as_ref().expect("l2_url not set"))
+            .arg("--builder-auth-url")
+            .arg(self.builder_url.as_ref().expect("builder_url not set"))
+            .arg("--builder-http-url")
             .arg(self.builder_url.as_ref().expect("builder_url not set"))
             .arg("--rpc-port")
             .arg(Arg::Port {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ use client::{BuilderArgs, ExecutionClient, L2ClientArgs};
 use std::{net::SocketAddr, sync::Arc};
 
 use dotenv::dotenv;
-use eyre::bail;
 use http::StatusCode;
 use hyper::service::service_fn;
 use hyper::{server::conn::http1, Request, Response};
@@ -18,7 +17,6 @@ use opentelemetry::global;
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::Config, Resource};
 use proxy::ProxyLayer;
-use reth_rpc_layer::JwtSecret;
 use server::RollupBoostServer;
 
 use tokio::net::TcpListener;

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,7 +257,6 @@ async fn init_metrics_server(addr: SocketAddr, handle: PrometheusHandle) -> eyre
 
 #[cfg(test)]
 mod tests {
-    use assert_cmd::Command;
     use http::Uri;
     use jsonrpsee::core::client::ClientT;
 
@@ -270,7 +269,6 @@ mod tests {
         rpc_params,
         server::{ServerBuilder, ServerHandle},
     };
-    use predicates::prelude::*;
     use reth_rpc_layer::{AuthClientService, AuthLayer, JwtAuthValidator, JwtSecret};
     use std::result::Result;
     use std::str::FromStr;
@@ -280,16 +278,6 @@ mod tests {
     const AUTH_PORT: u32 = 8550;
     const AUTH_ADDR: &str = "0.0.0.0";
     const SECRET: &str = "f79ae8046bc11c9927afe911db7143c51a806c4a537cc08e0d37140b0192f430";
-
-    #[test]
-    fn test_invalid_args() {
-        let mut cmd = Command::cargo_bin("rollup-boost").unwrap();
-        cmd.arg("--invalid-arg");
-
-        cmd.assert().failure().stderr(predicate::str::contains(
-            "error: unexpected argument '--invalid-arg' found",
-        ));
-    }
 
     #[tokio::test]
     async fn test_create_client() {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -206,7 +206,7 @@ mod tests {
         types::{ErrorCode, ErrorObject},
         RpcModule,
     };
-    use reth_rpc_layer::JwtSecret;
+    
     use serde_json::json;
     use std::{
         net::{IpAddr, SocketAddr},
@@ -385,7 +385,7 @@ mod tests {
                 }
             };
 
-            return Ok(hyper::Response::new(response.to_string()));
+            Ok(hyper::Response::new(response.to_string()))
         }
     }
 
@@ -674,7 +674,7 @@ mod tests {
 
         test_harness
             .proxy_client
-            .request::<serde_json::Value, _>(expected_method, (gas_price.clone(),))
+            .request::<serde_json::Value, _>(expected_method, (gas_price,))
             .await?;
 
         let expected_price = json!(gas_price);
@@ -708,7 +708,7 @@ mod tests {
 
         test_harness
             .proxy_client
-            .request::<serde_json::Value, _>(expected_method, (gas_limit.clone(),))
+            .request::<serde_json::Value, _>(expected_method, (gas_limit,))
             .await?;
 
         let expected_price = json!(gas_limit);
@@ -742,7 +742,7 @@ mod tests {
 
         test_harness
             .proxy_client
-            .request::<serde_json::Value, _>(expected_method, (mock_data.clone(),))
+            .request::<serde_json::Value, _>(expected_method, (mock_data,))
             .await?;
 
         let expected_price = json!(mock_data);

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -28,24 +28,24 @@ const FORWARD_REQUESTS: [&str; 6] = [
 
 #[derive(Debug, Clone)]
 pub struct ProxyLayer {
-    l2_auth_uri: Uri,
-    l2_auth_secret: JwtSecret,
-    builder_auth_uri: Uri,
-    builder_auth_secret: JwtSecret,
+    l2_http_uri: Uri,
+    l2_http_secret: Option<JwtSecret>,
+    builder_http_uri: Uri,
+    builder_http_secret: Option<JwtSecret>,
 }
 
 impl ProxyLayer {
     pub fn new(
-        l2_auth_uri: Uri,
-        l2_auth_secret: JwtSecret,
-        builder_auth_uri: Uri,
-        builder_auth_secret: JwtSecret,
+        l2_http_uri: Uri,
+        l2_http_secret: Option<JwtSecret>,
+        builder_http_uri: Uri,
+        builder_http_secret: Option<JwtSecret>,
     ) -> Self {
         ProxyLayer {
-            l2_auth_uri,
-            l2_auth_secret,
-            builder_auth_uri,
-            builder_auth_secret,
+            l2_http_uri,
+            l2_http_secret,
+            builder_http_uri,
+            builder_http_secret,
         }
     }
 }
@@ -57,10 +57,10 @@ impl<S> Layer<S> for ProxyLayer {
         ProxyService {
             inner,
             client: Client::builder(TokioExecutor::new()).build_http(),
-            l2_auth_uri: self.l2_auth_uri.clone(),
-            l2_auth_secret: self.l2_auth_secret,
-            builder_auth_uri: self.builder_auth_uri.clone(),
-            builder_auth_secret: self.builder_auth_secret,
+            l2_http_uri: self.l2_http_uri.clone(),
+            l2_http_secret: self.l2_http_secret,
+            builder_http_uri: self.builder_http_uri.clone(),
+            builder_http_secret: self.builder_http_secret,
         }
     }
 }
@@ -69,10 +69,10 @@ impl<S> Layer<S> for ProxyLayer {
 pub struct ProxyService<S> {
     inner: S,
     client: Client<HttpConnector, HttpBody>,
-    l2_auth_uri: Uri,
-    l2_auth_secret: JwtSecret,
-    builder_auth_uri: Uri,
-    builder_auth_secret: JwtSecret,
+    l2_http_uri: Uri,
+    l2_http_secret: Option<JwtSecret>,
+    builder_http_uri: Uri,
+    builder_http_secret: Option<JwtSecret>,
 }
 
 impl<S> Service<HttpRequest<HttpBody>> for ProxyService<S>
@@ -98,10 +98,10 @@ where
 
         let client = self.client.clone();
         let mut inner = self.inner.clone();
-        let builder_uri = self.builder_auth_uri.clone();
-        let builder_secret = self.builder_auth_secret;
-        let l2_uri = self.l2_auth_uri.clone();
-        let l2_secret = self.l2_auth_secret;
+        let builder_uri = self.builder_http_uri.clone();
+        let builder_secret = self.builder_http_secret;
+        let l2_uri = self.l2_http_uri.clone();
+        let l2_secret = self.l2_http_secret;
 
         #[derive(serde::Deserialize, Debug)]
         struct RpcRequest<'a> {
@@ -159,11 +159,13 @@ async fn forward_request(
     mut req: http::Request<HttpBody>,
     method: &str,
     uri: Uri,
-    auth: JwtSecret,
+    auth: Option<JwtSecret>,
 ) -> Result<http::Response<HttpBody>, BoxError> {
-    *req.uri_mut() = uri.clone();
-    req.headers_mut()
-        .insert(AUTHORIZATION, secret_to_bearer_header(&auth));
+    if let Some(auth) = auth {
+        *req.uri_mut() = uri.clone();
+        req.headers_mut()
+            .insert(AUTHORIZATION, secret_to_bearer_header(&auth));
+    }
 
     debug!(
         target: "proxy::forward_request",
@@ -237,9 +239,9 @@ mod tests {
             let l2 = MockHttpServer::serve().await?;
             let middleware = tower::ServiceBuilder::new().layer(ProxyLayer::new(
                 format!("http://{}:{}", l2.addr.ip(), l2.addr.port()).parse::<Uri>()?,
-                JwtSecret::random(),
+                None,
                 format!("http://{}:{}", builder.addr.ip(), builder.addr.port()).parse::<Uri>()?,
-                JwtSecret::random(),
+                None,
             ));
 
             let temp_listener = TcpListener::bind("0.0.0.0:0").await?;
@@ -484,7 +486,6 @@ mod tests {
     async fn spawn_proxy_server() -> ServerHandle {
         let addr = format!("{ADDR}:{PORT}");
 
-        let jwt = JwtSecret::random();
         let l2_auth_uri = format!(
             "http://{}",
             SocketAddr::new(IpAddr::from_str(ADDR).unwrap(), PROXY_PORT as u16)
@@ -492,7 +493,7 @@ mod tests {
         .parse::<Uri>()
         .unwrap();
 
-        let proxy_layer = ProxyLayer::new(l2_auth_uri.clone(), jwt.clone(), l2_auth_uri, jwt);
+        let proxy_layer = ProxyLayer::new(l2_auth_uri.clone(), None, l2_auth_uri, None);
 
         // Create a layered server
         let server = ServerBuilder::default()

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -161,8 +161,9 @@ async fn forward_request(
     uri: Uri,
     auth: Option<JwtSecret>,
 ) -> Result<http::Response<HttpBody>, BoxError> {
+    *req.uri_mut() = uri.clone();
+
     if let Some(auth) = auth {
-        *req.uri_mut() = uri.clone();
         req.headers_mut()
             .insert(AUTHORIZATION, secret_to_bearer_header(&auth));
     }
@@ -206,7 +207,7 @@ mod tests {
         types::{ErrorCode, ErrorObject},
         RpcModule,
     };
-    
+
     use serde_json::json;
     use std::{
         net::{IpAddr, SocketAddr},


### PR DESCRIPTION
Currently, `rollup-boost` forwards all requests other than Engine API requests via the auth RPC endpoint. This requires that client implementations expose all methods in `FORWARD_REQUESTS` through their auth RPC endpoint, however this is not the case for `op-geth`. This PR introduces the `--l2-http-url` and `--builder-http-url` flags to forward all requests via the JSON RPC api (other than Engine API requests). 