### PR TITLE
feat(engine-api): Support `newPayloadV4` and `getPayloadV4`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5315,6 +5315,7 @@ dependencies = [
  "metrics-process",
  "metrics-util",
  "moka",
+ "op-alloy-consensus",
  "op-alloy-rpc-jsonrpsee",
  "op-alloy-rpc-types",
  "op-alloy-rpc-types-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 alloy-primitives = { version = "0.8.10", features = ["rand"] }
 op-alloy-rpc-types-engine = "0.10.5"
+op-alloy-consensus = "0.10.5"
 op-alloy-rpc-types = "0.10.5"
 op-alloy-rpc-jsonrpsee = { version = "0.10.5", features = ["client"] }
 alloy-rpc-types-engine = "0.11"

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,4 @@
-use clap::{arg, Parser};
+use clap::{Parser, arg};
 use http::Uri;
 use jsonrpsee::http_client::transport::HttpBackend;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};

--- a/src/integration/service_rb.rs
+++ b/src/integration/service_rb.rs
@@ -1,4 +1,4 @@
-use crate::integration::{poll_logs, Arg, IntegrationError, Service, ServiceCommand};
+use crate::integration::{Arg, IntegrationError, Service, ServiceCommand, poll_logs};
 use futures_util::Future;
 use std::{
     path::{Path, PathBuf},

--- a/src/integration/service_reth.rs
+++ b/src/integration/service_reth.rs
@@ -1,4 +1,4 @@
-use crate::integration::{poll_logs, Arg, IntegrationError, Service, ServiceCommand};
+use crate::integration::{Arg, IntegrationError, Service, ServiceCommand, poll_logs};
 use futures_util::Future;
 use std::{
     path::{Path, PathBuf},

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,12 +1,12 @@
-use http::header::AUTHORIZATION;
 use http::Uri;
+use http::header::AUTHORIZATION;
 use hyper_rustls::HttpsConnector;
-use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client;
+use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::rt::TokioExecutor;
-use jsonrpsee::core::{http_helpers, BoxError};
+use jsonrpsee::core::{BoxError, http_helpers};
 use jsonrpsee::http_client::{HttpBody, HttpRequest, HttpResponse};
-use reth_rpc_layer::{secret_to_bearer_header, JwtSecret};
+use reth_rpc_layer::{JwtSecret, secret_to_bearer_header};
 use std::task::{Context, Poll};
 use std::{future::Future, pin::Pin};
 use tower::{Layer, Service};
@@ -224,19 +224,19 @@ async fn forward_request(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{hex, Bytes, B256, U128, U64};
+    use alloy_primitives::{B256, Bytes, U64, U128, hex};
     use alloy_rpc_types_eth::erc4337::TransactionConditional;
     use http_body_util::BodyExt;
     use hyper::service::service_fn;
     use hyper_util::rt::TokioIo;
     use jsonrpsee::server::Server;
     use jsonrpsee::{
-        core::{client::ClientT, ClientError},
+        RpcModule,
+        core::{ClientError, client::ClientT},
         http_client::HttpClient,
         rpc_params,
         server::{ServerBuilder, ServerHandle},
         types::{ErrorCode, ErrorObject},
-        RpcModule,
     };
 
     use serde_json::json;
@@ -548,9 +548,10 @@ mod tests {
             .register_method("engine_method", |_, _, _| "engine response")
             .unwrap();
         module
-            .register_method("eth_sendRawTransaction", |_, _, _| {
-                "raw transaction response"
-            })
+            .register_method(
+                "eth_sendRawTransaction",
+                |_, _, _| "raw transaction response",
+            )
             .unwrap();
         module
             .register_method("non_existent_method", |_, _, _| "no proxy response")

--- a/src/server.rs
+++ b/src/server.rs
@@ -463,6 +463,7 @@ impl EngineApiServer for RollupBoostServer {
             })
     }
 
+    // TODO: update tracing, metrics, refactor
     async fn get_payload_v4(
         &self,
         payload_id: PayloadId,
@@ -471,6 +472,19 @@ impl EngineApiServer for RollupBoostServer {
         let l2_payload = self.l2_client.auth_client.get_payload_v4(payload_id);
 
         let builder_payload = Box::pin(async move {
+            if let Some(metrics) = &self.metrics {
+                metrics.get_payload_count.increment(1);
+            }
+            let parent_span = self
+                .payload_trace_context
+                .retrieve_by_payload_id(&payload_id);
+            let span = parent_span.clone().map(|span| {
+                self.payload_trace_context.tracer.start_with_context(
+                    "get_payload",
+                    &Context::current().with_remote_span_context(span.span_context().clone()),
+                )
+            });
+
             let builder = self.builder_client.clone();
             let payload_envelope = builder.auth_client.get_payload_v4(payload_id).await.map_err(|e| {
                 error!(message = "error calling get_payload_v4 from builder", "url" = ?builder.auth_rpc, "error" = %e, "payload_id" = %payload_id);
@@ -480,6 +494,10 @@ impl EngineApiServer for RollupBoostServer {
             let block_hash =
                 ExecutionPayload::from(payload_envelope.execution_payload.clone()).block_hash();
             info!(message = "received payload from builder", "local_payload_id" = %payload_id, "block_hash" = %block_hash);
+
+            if let Some(metrics) = &self.metrics {
+                metrics.new_payload_count.increment(1);
+            }
 
             let withdrawals_root = payload_envelope
                 .execution_payload
@@ -494,11 +512,20 @@ impl EngineApiServer for RollupBoostServer {
                 withdrawals_root: withdrawals_root.unwrap_or_default(),
             };
 
-            // TODO: check versioned hashes
             let payload_status = self.l2_client.auth_client.new_payload_v4(payload_v4, vec![], payload_envelope.parent_beacon_block_root, execution_requests).await.map_err(|e| {
-                error!(message = "error calling new_payload_v3 to validate builder payload", "url" = ?self.l2_client.auth_rpc, "error" = %e, "local_payload_id" = %payload_id);
+                error!(message = "error calling new_payload_v4 to validate builder payload", "url" = ?self.l2_client.auth_rpc, "error" = %e, "local_payload_id" = %payload_id);
                 e
             })?;
+
+            if let Some(mut s) = span {
+                s.end();
+            };
+            if let Some(mut parent) = parent_span {
+                let parent = Arc::get_mut(&mut parent);
+                if let Some(parent) = parent {
+                    parent.end();
+                }
+            };
 
             if payload_status.is_invalid() {
                 error!(message = "builder payload was not valid", "url" = ?builder.auth_rpc, "payload_status" = %payload_status.status, "local_payload_id" = %payload_id);
@@ -528,6 +555,7 @@ impl EngineApiServer for RollupBoostServer {
         })
     }
 
+    // TODO: update tracing, metrics, refactor
     async fn new_payload_v4(
         &self,
         payload: OpExecutionPayloadV4,
@@ -535,7 +563,76 @@ impl EngineApiServer for RollupBoostServer {
         parent_beacon_block_root: B256,
         execution_requests: Requests,
     ) -> RpcResult<PayloadStatus> {
-        todo!()
+        let execution_payload = ExecutionPayload::from(payload.payload_inner.clone());
+        let block_hash = execution_payload.block_hash();
+        let parent_hash = execution_payload.parent_hash();
+        info!(message = "received new_payload_v4", "block_hash" = %block_hash);
+
+        // async call to builder to sync the builder node
+        if self.boost_sync {
+            if let Some(metrics) = &self.metrics {
+                metrics.new_payload_count.increment(1);
+            }
+            let parent_spans = self
+                .payload_trace_context
+                .retrieve_by_parent_hash(&parent_hash);
+            let spans: Option<Vec<BoxedSpan>> = parent_spans.as_ref().map(|spans| {
+                spans
+                    .iter()
+                    .map(|span| {
+                        self.payload_trace_context.tracer.start_with_context(
+                            "new_payload",
+                            &Context::current()
+                                .with_remote_span_context(span.span_context().clone()),
+                        )
+                    })
+                    .collect()
+            });
+            self.payload_trace_context
+                .remove_by_parent_hash(&parent_hash);
+
+            let builder = self.builder_client.clone();
+            let builder_payload = payload.clone();
+            let builder_versioned_hashes = versioned_hashes.clone();
+            let builder_execution_requests = execution_requests.clone();
+            tokio::spawn(async move {
+                let _ = builder.auth_client.new_payload_v4(builder_payload, builder_versioned_hashes, parent_beacon_block_root, builder_execution_requests).await
+                .map(|response: PayloadStatus| {
+                    if response.is_invalid() {
+                        error!(message = "builder rejected new_payload_v4", "url" = ?builder.auth_rpc, "block_hash" = %block_hash);
+                    } else {
+                        info!(message = "called new_payload_v4 to builder", "url" = ?builder.auth_rpc, "payload_status" = %response.status, "block_hash" = %block_hash);
+                    }
+                }).map_err(|e| {
+                    error!(message = "error calling new_payload_v4 to builder", "url" = ?builder.auth_rpc, "error" = %e, "block_hash" = %block_hash);
+                    e
+                });
+                if let Some(mut spans) = spans {
+                    spans.iter_mut().for_each(|s| s.end());
+                };
+            });
+        }
+        self.l2_client
+            .auth_client
+            .new_payload_v4(
+                payload,
+                versioned_hashes,
+                parent_beacon_block_root,
+                execution_requests,
+            )
+            .await
+            .map_err(|e| match e {
+                ClientError::Call(err) => err,
+                other_error => {
+                    error!(
+                        message = "error calling new_payload_v4",
+                        "url" = ?self.l2_client.auth_rpc,
+                        "error" = %other_error,
+                        "block_hash" = %block_hash
+                    );
+                    ErrorCode::InternalError.into()
+                }
+            })
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,7 +2,6 @@ use crate::client::ExecutionClient;
 use crate::metrics::ServerMetrics;
 use alloy_eips::eip7685::Requests;
 use alloy_primitives::B256;
-use alloy_rpc_types_eth::Block;
 use moka::sync::Cache;
 use op_alloy_consensus::OpTxEnvelope;
 use std::sync::Arc;
@@ -510,7 +509,7 @@ impl EngineApiServer for RollupBoostServer {
 
             let execution_requests = Requests::from(payload_envelope.execution_requests.clone());
             let payload_v4 = OpExecutionPayloadV4 {
-                payload_inner: ExecutionPayloadV3::from(payload_envelope.execution_payload.clone()),
+                payload_inner: payload_envelope.execution_payload.clone(),
                 withdrawals_root: withdrawals_root.unwrap_or_default(),
             };
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,6 @@
 use crate::client::ExecutionClient;
 use crate::metrics::ServerMetrics;
+use alloy_eips::eip7685::Requests;
 use alloy_primitives::B256;
 use moka::sync::Cache;
 use std::sync::Arc;
@@ -12,7 +13,10 @@ use jsonrpsee::RpcModule;
 use jsonrpsee::core::{ClientError, RegisterMethodError, RpcResult, async_trait};
 use jsonrpsee::types::error::INVALID_REQUEST_CODE;
 use jsonrpsee::types::{ErrorCode, ErrorObject};
-use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelopeV3, OpPayloadAttributes};
+use op_alloy_rpc_types_engine::{
+    OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4, OpExecutionPayloadV4,
+    OpPayloadAttributes,
+};
 use opentelemetry::global::{self, BoxedSpan, BoxedTracer};
 use opentelemetry::trace::{Span, TraceContextExt, Tracer};
 use opentelemetry::{Context, KeyValue};
@@ -154,6 +158,21 @@ pub trait EngineApi {
         versioned_hashes: Vec<B256>,
         parent_beacon_block_root: B256,
     ) -> RpcResult<PayloadStatus>;
+
+    #[method(name = "newPayloadV4")]
+    async fn new_payload_v4(
+        &self,
+        payload: OpExecutionPayloadV4,
+        versioned_hashes: Vec<B256>,
+        parent_beacon_block_root: B256,
+        execution_requests: Requests,
+    ) -> RpcResult<PayloadStatus>;
+
+    #[method(name = "getPayloadV4")]
+    async fn get_payload_v4(
+        &self,
+        payload_id: PayloadId,
+    ) -> RpcResult<OpExecutionPayloadEnvelopeV4>;
 }
 
 #[async_trait]

--- a/src/server.rs
+++ b/src/server.rs
@@ -478,8 +478,11 @@ impl EngineApiServer for RollupBoostServer {
             let block_hash = ExecutionPayload::from(payload.clone().execution_payload).block_hash();
             info!(message = "received payload from builder", "local_payload_id" = %payload_id, "block_hash" = %block_hash);
 
-            let payload_status = self.l2_client.auth_client.new_payload_v4(payload.execution_payload.clone(), vec![], payload.parent_beacon_block_root).await.map_err(|e| {
-                error!(message = "error calling new_payload_v3 to validate builder payload", "url" = ?self.l2_client.auth_rpc, "error" = %e, "local_payload_id" = %payload_id, "external_payload_id" = %external_payload_id);
+            let execution_requests = Requests::from(payload.execution_requests);
+
+            // TODO: check versioned hases
+            let payload_status = self.l2_client.auth_client.new_payload_v4(payload.into(), vec![], payload.parent_beacon_block_root, execution_requests).await.map_err(|e| {
+                error!(message = "error calling new_payload_v3 to validate builder payload", "url" = ?self.l2_client.auth_rpc, "error" = %e, "local_payload_id" = %payload_id);
                 e
             })?;
 
@@ -491,7 +494,7 @@ impl EngineApiServer for RollupBoostServer {
                     None::<String>,
                 )))
             } else {
-                info!(message = "received payload status from local execution engine validating builder payload", "local_payload_id" = %payload_id, "external_payload_id" = %external_payload_id);
+                info!(message = "received payload status from local execution engine validating builder payload", "local_payload_id" = %payload_id);
                 Ok(payload)
             }
         });

--- a/src/server.rs
+++ b/src/server.rs
@@ -309,6 +309,7 @@ impl EngineApiServer for RollupBoostServer {
         Ok(l2_response)
     }
 
+    // TODO: update tracing, metrics, refactor
     async fn get_payload_v3(
         &self,
         payload_id: PayloadId,
@@ -392,6 +393,7 @@ impl EngineApiServer for RollupBoostServer {
         })
     }
 
+    // TODO: update tracing, metrics, refactor
     async fn new_payload_v3(
         &self,
         payload: ExecutionPayloadV3,


### PR DESCRIPTION
This PR introduces `newPayloadV4` and `getPayloadV4` methods on the Engine API ahead of the Isthmus hardfork. 

The implementation closely follows `newPayloadV3` and `getPayloadV3` and can be significantly refactored. 

I will open a separate PR to refactor and simplify the implementation. 







