### PR TITLE
Osiris/background health check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3775,6 +3775,7 @@ dependencies = [
 name = "rollup-boost"
 version = "0.1.0"
 dependencies = [
+ "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 op-alloy-rpc-types-engine = "0.12.0"
 alloy-rpc-types-engine = "0.13.0"
+alloy-rpc-types-eth = "0.13.0"
 alloy-primitives = { version = "0.8.10", features = ["rand"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1.4"
@@ -51,7 +52,7 @@ rand = "0.9.0"
 time = { version = "0.3.36", features = ["macros", "formatting", "parsing"] }
 op-alloy-consensus = "0.12.0"
 alloy-eips = { version = "0.13.0", features = ["serde"] }
-alloy-rpc-types-eth = "0.13.0"
+alloy-consensus = {version = "0.13.0", features = ["serde"] }
 anyhow = "1.0"
 testcontainers = { version = "0.23.3" }
 assert_cmd = "2.0.10"

--- a/scripts/ci/stress.sh
+++ b/scripts/ci/stress.sh
@@ -32,8 +32,8 @@ run() {
     # the transactions will be included in the canonical blocks and finalized.
 
     # Figure out first the builder's JSON-RPC URL
-    ROLLUP_BOOST_SOCKET=$(kurtosis port print op-rollup-boost op-rollup-boost-1-op-kurtosis rpc)
-    OP_RETH_BUILDER_SOCKET=$(kurtosis port print op-rollup-boost op-el-builder-1-op-reth-op-node-op-kurtosis rpc)
+    ROLLUP_BOOST_SOCKET=$(kurtosis port print op-rollup-boost op-rollup-boost-2151908-1-op-kurtosis rpc)
+    OP_RETH_BUILDER_SOCKET=$(kurtosis port print op-rollup-boost op-el-builder-2151908-1-op-reth-op-node-op-kurtosis rpc)
 
     # Private key with prefunded balance
     PREFUNDED_PRIV_KEY=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,6 +31,10 @@ pub struct Args {
     #[arg(long, env, default_value = "60")]
     pub health_check_interval: u64,
 
+    /// Max duration in seconds between the unsafe head block and the current time to be considered healthy
+    #[arg(long, env, default_value = "5")]
+    pub max_unsafe_interval: u64,
+
     /// Disable using the proposer to sync the builder node
     #[arg(long, env, default_value = "false")]
     pub no_boost_sync: bool,
@@ -169,6 +173,7 @@ impl Args {
             self.execution_mode,
             probes,
             self.health_check_interval,
+            self.max_unsafe_interval,
         );
 
         // Spawn the debug server

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,6 +27,10 @@ pub struct Args {
     #[clap(flatten)]
     pub l2_client: L2ClientArgs,
 
+    /// Duration in seconds between async health checks on the builder, and the l2 client
+    #[arg(long, env, default_value = "60")]
+    pub health_check_interval: u64,
+
     /// Disable using the proposer to sync the builder node
     #[arg(long, env, default_value = "false")]
     pub no_boost_sync: bool,
@@ -164,6 +168,7 @@ impl Args {
             boost_sync_enabled,
             self.execution_mode,
             probes,
+            self.health_check_interval,
         );
 
         // Spawn the debug server

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,11 +27,11 @@ pub struct Args {
     #[clap(flatten)]
     pub l2_client: L2ClientArgs,
 
-    /// Duration in seconds between async health checks on the builder, and the l2 client
+    /// Duration in seconds between async health checks on the builder
     #[arg(long, env, default_value = "60")]
     pub health_check_interval: u64,
 
-    /// Max duration in seconds between the unsafe head block and the current time to be considered healthy
+    /// Max duration in seconds between the unsafe head block of the builder and the current time
     #[arg(long, env, default_value = "5")]
     pub max_unsafe_interval: u64,
 

--- a/src/client/rpc.rs
+++ b/src/client/rpc.rs
@@ -322,6 +322,12 @@ impl RpcClient {
             }
         }
     }
+
+    pub async fn get_block_number(&self) -> ClientResult<u64> {
+        info!("Sending get_block_number to {}", self.payload_source);
+        let block_number = self.auth_client.get_block_number().await.set_code()?;
+        Ok(block_number)
+    }
 }
 
 /// Generates Clap argument structs with a prefix to create a unique namespace when specifying RPC client config via the CLI.

--- a/src/client/rpc.rs
+++ b/src/client/rpc.rs
@@ -2,11 +2,13 @@ use crate::client::auth::AuthLayer;
 use crate::server::{
     EngineApiClient, NewPayload, OpExecutionPayloadEnvelope, PayloadSource, Version,
 };
-use alloy_primitives::{B256, Bytes, U256};
+
+use alloy_primitives::{B256, Bytes};
 use alloy_rpc_types_engine::{
     ExecutionPayload, ExecutionPayloadV3, ForkchoiceState, ForkchoiceUpdated, JwtError, JwtSecret,
     PayloadId, PayloadStatus,
 };
+use alloy_rpc_types_eth::{Block, BlockNumberOrTag};
 use clap::{Parser, arg};
 use http::Uri;
 use jsonrpsee::http_client::transport::HttpBackend;
@@ -323,9 +325,16 @@ impl RpcClient {
         }
     }
 
-    pub async fn block_number(&self) -> ClientResult<U256> {
-        let block_number = self.auth_client.block_number().await.set_code()?;
-        Ok(block_number)
+    pub async fn get_block_by_number(
+        &self,
+        number: BlockNumberOrTag,
+        full: bool,
+    ) -> ClientResult<Block> {
+        Ok(self
+            .auth_client
+            .get_block_by_number(number, full)
+            .await
+            .set_code()?)
     }
 }
 

--- a/src/client/rpc.rs
+++ b/src/client/rpc.rs
@@ -2,7 +2,7 @@ use crate::client::auth::AuthLayer;
 use crate::server::{
     EngineApiClient, NewPayload, OpExecutionPayloadEnvelope, PayloadSource, Version,
 };
-use alloy_primitives::{B256, Bytes};
+use alloy_primitives::{B256, Bytes, U256};
 use alloy_rpc_types_engine::{
     ExecutionPayload, ExecutionPayloadV3, ForkchoiceState, ForkchoiceUpdated, JwtError, JwtSecret,
     PayloadId, PayloadStatus,
@@ -323,9 +323,8 @@ impl RpcClient {
         }
     }
 
-    pub async fn get_block_number(&self) -> ClientResult<u64> {
-        info!("Sending get_block_number to {}", self.payload_source);
-        let block_number = self.auth_client.get_block_number().await.set_code()?;
+    pub async fn block_number(&self) -> ClientResult<U256> {
+        let block_number = self.auth_client.block_number().await.set_code()?;
         Ok(block_number)
     }
 }

--- a/src/health.rs
+++ b/src/health.rs
@@ -49,3 +49,230 @@ impl HealthHandle {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::net::SocketAddr;
+
+    use alloy_primitives::U256;
+    use http::Uri;
+    use http_body_util::BodyExt;
+    use hyper::service::service_fn;
+    use hyper_util::rt::TokioIo;
+    use reth_rpc_layer::JwtSecret;
+    use serde_json::json;
+    use tokio::net::TcpListener;
+
+    use super::*;
+    use crate::{PayloadSource, Probes};
+
+    pub struct MockHttpServer {
+        addr: SocketAddr,
+        join_handle: JoinHandle<()>,
+    }
+
+    impl Drop for MockHttpServer {
+        fn drop(&mut self) {
+            self.join_handle.abort();
+        }
+    }
+
+    impl MockHttpServer {
+        async fn serve<S>(f: fn(hyper::Request<hyper::body::Incoming>) -> S) -> eyre::Result<Self>
+        where
+            S: Future<Output = Result<hyper::Response<String>, hyper::Error>>
+                + Send
+                + Sync
+                + 'static,
+        {
+            {
+                let listener = TcpListener::bind("0.0.0.0:0").await?;
+                let addr = listener.local_addr()?;
+
+                let handle = tokio::spawn(async move {
+                    loop {
+                        match listener.accept().await {
+                            Ok((stream, _)) => {
+                                let io = TokioIo::new(stream);
+                                tokio::spawn(async move {
+                                    if let Err(err) = hyper::server::conn::http1::Builder::new()
+                                        .serve_connection(io, service_fn(move |req| f(req)))
+                                        .await
+                                    {
+                                        eprintln!("Error serving connection: {}", err);
+                                    }
+                                });
+                            }
+                            Err(e) => eprintln!("Error accepting connection: {}", e),
+                        }
+                    }
+                });
+
+                Ok(Self {
+                    addr,
+                    join_handle: handle,
+                })
+            }
+        }
+    }
+
+    async fn handler_0(
+        req: hyper::Request<hyper::body::Incoming>,
+    ) -> Result<hyper::Response<String>, hyper::Error> {
+        let body_bytes = match req.into_body().collect().await {
+            Ok(buf) => buf.to_bytes(),
+            Err(_) => {
+                let error_response = json!({
+                    "jsonrpc": "2.0",
+                    "error": { "code": -32700, "message": "Failed to read request body" },
+                    "id": null
+                });
+                return Ok(hyper::Response::new(error_response.to_string()));
+            }
+        };
+
+        let request_body: serde_json::Value = match serde_json::from_slice(&body_bytes) {
+            Ok(json) => json,
+            Err(_) => {
+                let error_response = json!({
+                    "jsonrpc": "2.0",
+                    "error": { "code": -32700, "message": "Invalid JSON format" },
+                    "id": null
+                });
+                return Ok(hyper::Response::new(error_response.to_string()));
+            }
+        };
+
+        let method = request_body["method"].as_str().unwrap_or_default();
+
+        let response = match method {
+            "eth_blockNumber" => json!({
+                "jsonrpc": "2.0",
+                "result": format!("{}", U256::ZERO),
+                "id": request_body["id"]
+            }),
+            _ => {
+                let error_response = json!({
+                    "jsonrpc": "2.0",
+                    "error": { "code": -32601, "message": "Method not found" },
+                    "id": request_body["id"]
+                });
+                return Ok(hyper::Response::new(error_response.to_string()));
+            }
+        };
+
+        Ok(hyper::Response::new(response.to_string()))
+    }
+
+    async fn handler_1(
+        req: hyper::Request<hyper::body::Incoming>,
+    ) -> Result<hyper::Response<String>, hyper::Error> {
+        let body_bytes = match req.into_body().collect().await {
+            Ok(buf) => buf.to_bytes(),
+            Err(_) => {
+                let error_response = json!({
+                    "jsonrpc": "2.0",
+                    "error": { "code": -32700, "message": "Failed to read request body" },
+                    "id": null
+                });
+                return Ok(hyper::Response::new(error_response.to_string()));
+            }
+        };
+
+        let request_body: serde_json::Value = match serde_json::from_slice(&body_bytes) {
+            Ok(json) => json,
+            Err(_) => {
+                let error_response = json!({
+                    "jsonrpc": "2.0",
+                    "error": { "code": -32700, "message": "Invalid JSON format" },
+                    "id": null
+                });
+                return Ok(hyper::Response::new(error_response.to_string()));
+            }
+        };
+
+        let method = request_body["method"].as_str().unwrap_or_default();
+
+        let response = match method {
+            "eth_blockNumber" => json!({
+                "jsonrpc": "2.0",
+                "result": format!("{}", U256::from(1)),
+                "id": request_body["id"]
+            }),
+            _ => {
+                let error_response = json!({
+                    "jsonrpc": "2.0",
+                    "error": { "code": -32601, "message": "Method not found" },
+                    "id": request_body["id"]
+                });
+                return Ok(hyper::Response::new(error_response.to_string()));
+            }
+        };
+
+        Ok(hyper::Response::new(response.to_string()))
+    }
+
+    #[tokio::test]
+    async fn test_health_check_healthy() -> eyre::Result<()> {
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        let probes = Arc::new(Probes::default());
+        let builder = MockHttpServer::serve(handler_0).await.unwrap();
+        let l2 = MockHttpServer::serve(handler_0).await.unwrap();
+
+        let builder_client = Arc::new(RpcClient::new(
+            format!("http://{}", builder.addr).parse::<Uri>()?,
+            JwtSecret::random(),
+            100,
+            PayloadSource::Builder,
+        )?);
+        let l2_client = Arc::new(RpcClient::new(
+            format!("http://{}", l2.addr).parse::<Uri>()?,
+            JwtSecret::random(),
+            100,
+            PayloadSource::L2,
+        )?);
+        let health_handle = HealthHandle {
+            probes: probes.clone(),
+            builder_client: builder_client.clone(),
+            l2_client: l2_client.clone(),
+            health_check_interval: 60,
+        };
+
+        let _ = health_handle.spawn();
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        assert!(matches!(probes.health(), Health::Healthy));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_health_check_partial_content() -> eyre::Result<()> {
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        let probes = Arc::new(Probes::default());
+        let builder = MockHttpServer::serve(handler_0).await.unwrap();
+        let l2 = MockHttpServer::serve(handler_1).await.unwrap();
+
+        let builder_client = Arc::new(RpcClient::new(
+            format!("http://{}", builder.addr).parse::<Uri>()?,
+            JwtSecret::random(),
+            100,
+            PayloadSource::Builder,
+        )?);
+        let l2_client = Arc::new(RpcClient::new(
+            format!("http://{}", l2.addr).parse::<Uri>()?,
+            JwtSecret::random(),
+            100,
+            PayloadSource::L2,
+        )?);
+        let health_handle = HealthHandle {
+            probes: probes.clone(),
+            builder_client: builder_client.clone(),
+            l2_client: l2_client.clone(),
+            health_check_interval: 60,
+        };
+
+        let _ = health_handle.spawn();
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        assert!(matches!(probes.health(), Health::PartialContent));
+        Ok(())
+    }
+}

--- a/src/health.rs
+++ b/src/health.rs
@@ -1,0 +1,53 @@
+use std::{sync::Arc, time::Duration};
+
+use tokio::{
+    task::JoinHandle,
+    time::{Instant, sleep_until},
+};
+use tracing::{error, info};
+
+use crate::{Health, Probes, RpcClient};
+
+pub struct HealthHandle {
+    pub probes: Arc<Probes>,
+    pub builder_client: Arc<RpcClient>,
+    pub l2_client: Arc<RpcClient>,
+    pub health_check_interval: u64,
+}
+
+impl HealthHandle {
+    pub fn spawn(self) -> JoinHandle<()> {
+        let handle = tokio::spawn(async move {
+            loop {
+                let (l2_block_height, builder_block_height) = tokio::join!(
+                    self.l2_client.get_block_number(),
+                    self.builder_client.get_block_number()
+                );
+                match l2_block_height {
+                    Err(e) => {
+                        error!(target: "rollup_boost::health", "Failed to get block height from l2 client: {}", e);
+                        self.probes.set_health(Health::ServiceUnavailable);
+                    }
+                    Ok(l2_block_height) => match builder_block_height {
+                        Err(e) => {
+                            error!(target: "rollup_boost::health", "Failed to get block height from builder client: {}", e);
+                            self.probes.set_health(Health::PartialContent);
+                        }
+                        Ok(builder_block_height) => {
+                            if builder_block_height != l2_block_height {
+                                error!(target: "rollup_boost::health", "Builder and L2 client block heights do not match: builder: {}, l2: {}", builder_block_height, l2_block_height);
+                                self.probes.set_health(Health::PartialContent);
+                            } else {
+                                info!(target: "rollup_boost::health", %builder_block_height, "Health Status Check Passed - Builder and L2 client block heights match");
+                                self.probes.set_health(Health::Healthy);
+                            }
+                        }
+                    },
+                }
+                sleep_until(Instant::now() + Duration::from_secs(self.health_check_interval)).await;
+            }
+        });
+
+        handle
+    }
+}

--- a/src/health.rs
+++ b/src/health.rs
@@ -17,7 +17,7 @@ pub struct HealthHandle {
 
 impl HealthHandle {
     pub fn spawn(self) -> JoinHandle<()> {
-        let handle = tokio::spawn(async move {
+        tokio::spawn(async move {
             loop {
                 let (l2_block_height, builder_block_height) = tokio::join!(
                     self.l2_client.block_number(),
@@ -46,8 +46,6 @@ impl HealthHandle {
                 }
                 sleep_until(Instant::now() + Duration::from_secs(self.health_check_interval)).await;
             }
-        });
-
-        handle
+        })
     }
 }

--- a/src/health.rs
+++ b/src/health.rs
@@ -1,49 +1,54 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
+use alloy_rpc_types_eth::BlockNumberOrTag;
 use tokio::{
     task::JoinHandle,
     time::{Instant, sleep_until},
 };
-use tracing::{error, info};
+use tracing::warn;
 
 use crate::{Health, Probes, RpcClient};
 
 pub struct HealthHandle {
     pub probes: Arc<Probes>,
     pub builder_client: Arc<RpcClient>,
-    pub l2_client: Arc<RpcClient>,
     pub health_check_interval: u64,
+    pub max_unsafe_interval: u64,
 }
 
 impl HealthHandle {
+    /// Periodically checks that the latest unsafe block is not older than the max_unsafe_interval by a specified threshold.
     pub fn spawn(self) -> JoinHandle<()> {
         tokio::spawn(async move {
             loop {
-                let (l2_block_height, builder_block_height) = tokio::join!(
-                    self.l2_client.block_number(),
-                    self.builder_client.block_number()
-                );
-                match l2_block_height {
+                let latest_unsafe = match self
+                    .builder_client
+                    .get_block_by_number(BlockNumberOrTag::Latest, false)
+                    .await
+                {
+                    Ok(block) => block,
                     Err(e) => {
-                        error!(target: "rollup_boost::health", "Failed to get block height from l2 client: {}", e);
-                        self.probes.set_health(Health::ServiceUnavailable);
+                        warn!(target: "rollup_boost::health", "Failed to get unsafe block from builder client: {} - updating health status", e);
+                        self.probes.set_health(Health::PartialContent);
+                        continue;
                     }
-                    Ok(l2_block_height) => match builder_block_height {
-                        Err(e) => {
-                            error!(target: "rollup_boost::health", "Failed to get block height from builder client: {}", e);
-                            self.probes.set_health(Health::PartialContent);
-                        }
-                        Ok(builder_block_height) => {
-                            if builder_block_height != l2_block_height {
-                                error!(target: "rollup_boost::health", "Builder and L2 client block heights do not match: builder: {}, l2: {}", builder_block_height, l2_block_height);
-                                self.probes.set_health(Health::PartialContent);
-                            } else {
-                                info!(target: "rollup_boost::health", %builder_block_height, "Health Status Check Passed - Builder and L2 client block heights match");
-                                self.probes.set_health(Health::Healthy);
-                            }
-                        }
-                    },
+                };
+
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .expect("Time went backwards")
+                    .as_secs();
+
+                if now - latest_unsafe.header.timestamp > self.max_unsafe_interval {
+                    warn!(target: "rollup_boost::health", "Unsafe block timestamp is too old ({} seconds - updating health status)", now - latest_unsafe.header.timestamp);
+                    self.probes.set_health(Health::PartialContent);
+                } else {
+                    self.probes.set_health(Health::Healthy);
                 }
+
                 sleep_until(Instant::now() + Duration::from_secs(self.health_check_interval)).await;
             }
         })
@@ -54,7 +59,9 @@ impl HealthHandle {
 mod tests {
     use std::net::SocketAddr;
 
-    use alloy_primitives::U256;
+    use alloy_consensus::Header;
+    use alloy_rpc_types_eth::{Block, Header as EthHeader, Transaction};
+
     use http::Uri;
     use http_body_util::BodyExt;
     use hyper::service::service_fn;
@@ -78,7 +85,10 @@ mod tests {
     }
 
     impl MockHttpServer {
-        async fn serve<S>(f: fn(hyper::Request<hyper::body::Incoming>) -> S) -> eyre::Result<Self>
+        async fn serve<S>(
+            f: fn(hyper::Request<hyper::body::Incoming>, timestamp: u64) -> S,
+            timestamp: u64,
+        ) -> eyre::Result<Self>
         where
             S: Future<Output = Result<hyper::Response<String>, hyper::Error>>
                 + Send
@@ -96,7 +106,10 @@ mod tests {
                                 let io = TokioIo::new(stream);
                                 tokio::spawn(async move {
                                     if let Err(err) = hyper::server::conn::http1::Builder::new()
-                                        .serve_connection(io, service_fn(move |req| f(req)))
+                                        .serve_connection(
+                                            io,
+                                            service_fn(move |req| f(req, timestamp)),
+                                        )
                                         .await
                                     {
                                         eprintln!("Error serving connection: {}", err);
@@ -116,8 +129,9 @@ mod tests {
         }
     }
 
-    async fn handler_0(
+    async fn handler(
         req: hyper::Request<hyper::body::Incoming>,
+        block_timstamp: u64,
     ) -> Result<hyper::Response<String>, hyper::Error> {
         let body_bytes = match req.into_body().collect().await {
             Ok(buf) => buf.to_bytes(),
@@ -145,58 +159,21 @@ mod tests {
 
         let method = request_body["method"].as_str().unwrap_or_default();
 
-        let response = match method {
-            "eth_blockNumber" => json!({
-                "jsonrpc": "2.0",
-                "result": format!("{}", U256::ZERO),
-                "id": request_body["id"]
-            }),
-            _ => {
-                let error_response = json!({
-                    "jsonrpc": "2.0",
-                    "error": { "code": -32601, "message": "Method not found" },
-                    "id": request_body["id"]
-                });
-                return Ok(hyper::Response::new(error_response.to_string()));
-            }
+        let mock_block = Block::<Transaction> {
+            header: EthHeader {
+                inner: Header {
+                    timestamp: block_timstamp,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
         };
-
-        Ok(hyper::Response::new(response.to_string()))
-    }
-
-    async fn handler_1(
-        req: hyper::Request<hyper::body::Incoming>,
-    ) -> Result<hyper::Response<String>, hyper::Error> {
-        let body_bytes = match req.into_body().collect().await {
-            Ok(buf) => buf.to_bytes(),
-            Err(_) => {
-                let error_response = json!({
-                    "jsonrpc": "2.0",
-                    "error": { "code": -32700, "message": "Failed to read request body" },
-                    "id": null
-                });
-                return Ok(hyper::Response::new(error_response.to_string()));
-            }
-        };
-
-        let request_body: serde_json::Value = match serde_json::from_slice(&body_bytes) {
-            Ok(json) => json,
-            Err(_) => {
-                let error_response = json!({
-                    "jsonrpc": "2.0",
-                    "error": { "code": -32700, "message": "Invalid JSON format" },
-                    "id": null
-                });
-                return Ok(hyper::Response::new(error_response.to_string()));
-            }
-        };
-
-        let method = request_body["method"].as_str().unwrap_or_default();
 
         let response = match method {
-            "eth_blockNumber" => json!({
+            "eth_getBlockByNumber" => json!({
                 "jsonrpc": "2.0",
-                "result": format!("{}", U256::from(1)),
+                "result": mock_block,
                 "id": request_body["id"]
             }),
             _ => {
@@ -216,26 +193,24 @@ mod tests {
     async fn test_health_check_healthy() -> eyre::Result<()> {
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
         let probes = Arc::new(Probes::default());
-        let builder = MockHttpServer::serve(handler_0).await.unwrap();
-        let l2 = MockHttpServer::serve(handler_0).await.unwrap();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_secs();
 
+        let builder = MockHttpServer::serve(handler, now).await.unwrap();
         let builder_client = Arc::new(RpcClient::new(
             format!("http://{}", builder.addr).parse::<Uri>()?,
             JwtSecret::random(),
             100,
             PayloadSource::Builder,
         )?);
-        let l2_client = Arc::new(RpcClient::new(
-            format!("http://{}", l2.addr).parse::<Uri>()?,
-            JwtSecret::random(),
-            100,
-            PayloadSource::L2,
-        )?);
+
         let health_handle = HealthHandle {
             probes: probes.clone(),
             builder_client: builder_client.clone(),
-            l2_client: l2_client.clone(),
             health_check_interval: 60,
+            max_unsafe_interval: 5,
         };
 
         let _ = health_handle.spawn();
@@ -245,11 +220,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_health_check_partial_content() -> eyre::Result<()> {
+    async fn test_health_check_exceeds_max_unsafe_interval() -> eyre::Result<()> {
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
         let probes = Arc::new(Probes::default());
-        let builder = MockHttpServer::serve(handler_0).await.unwrap();
-        let l2 = MockHttpServer::serve(handler_1).await.unwrap();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_secs();
+        let builder = MockHttpServer::serve(handler, now - 10).await.unwrap();
 
         let builder_client = Arc::new(RpcClient::new(
             format!("http://{}", builder.addr).parse::<Uri>()?,
@@ -257,17 +235,36 @@ mod tests {
             100,
             PayloadSource::Builder,
         )?);
-        let l2_client = Arc::new(RpcClient::new(
-            format!("http://{}", l2.addr).parse::<Uri>()?,
-            JwtSecret::random(),
-            100,
-            PayloadSource::L2,
-        )?);
+
         let health_handle = HealthHandle {
             probes: probes.clone(),
             builder_client: builder_client.clone(),
-            l2_client: l2_client.clone(),
             health_check_interval: 60,
+            max_unsafe_interval: 5,
+        };
+
+        let _ = health_handle.spawn();
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        assert!(matches!(probes.health(), Health::PartialContent));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_health_check_service_unavailable() -> eyre::Result<()> {
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        let probes = Arc::new(Probes::default());
+        let builder_client = Arc::new(RpcClient::new(
+            "http://127.0.0.1:6000".parse::<Uri>()?,
+            JwtSecret::random(),
+            100,
+            PayloadSource::Builder,
+        )?);
+
+        let health_handle = HealthHandle {
+            probes: probes.clone(),
+            builder_client: builder_client.clone(),
+            health_check_interval: 60,
+            max_unsafe_interval: 5,
         };
 
         let _ = health_handle.spawn();

--- a/src/health.rs
+++ b/src/health.rs
@@ -20,8 +20,8 @@ impl HealthHandle {
         let handle = tokio::spawn(async move {
             loop {
                 let (l2_block_height, builder_block_height) = tokio::join!(
-                    self.l2_client.get_block_number(),
-                    self.builder_client.get_block_number()
+                    self.l2_client.block_number(),
+                    self.builder_client.block_number()
                 );
                 match l2_block_height {
                     Err(e) => {

--- a/src/health.rs
+++ b/src/health.rs
@@ -20,7 +20,7 @@ pub struct HealthHandle {
 }
 
 impl HealthHandle {
-    /// Periodically checks that the latest unsafe block timestamp is not older than the 
+    /// Periodically checks that the latest unsafe block timestamp is not older than the
     /// the current time minus the max_unsafe_interval.
     pub fn spawn(self) -> JoinHandle<()> {
         tokio::spawn(async move {
@@ -34,6 +34,10 @@ impl HealthHandle {
                     Err(e) => {
                         warn!(target: "rollup_boost::health", "Failed to get unsafe block from builder client: {} - updating health status", e);
                         self.probes.set_health(Health::PartialContent);
+                        sleep_until(
+                            Instant::now() + Duration::from_secs(self.health_check_interval),
+                        )
+                        .await;
                         continue;
                     }
                 };

--- a/src/health.rs
+++ b/src/health.rs
@@ -20,7 +20,8 @@ pub struct HealthHandle {
 }
 
 impl HealthHandle {
-    /// Periodically checks that the latest unsafe block is not older than the max_unsafe_interval by a specified threshold.
+    /// Periodically checks that the latest unsafe block timestamp is not older than the 
+    /// the current time minus the max_unsafe_interval.
     pub fn spawn(self) -> JoinHandle<()> {
         tokio::spawn(async move {
             loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,3 +24,6 @@ pub use tracing::*;
 
 mod probe;
 pub use probe::*;
+
+mod health;
+pub use health::*;

--- a/src/server.rs
+++ b/src/server.rs
@@ -143,6 +143,7 @@ impl RollupBoostServer {
         probes: Arc<Probes>,
         health_check_interval: u64,
     ) -> Self {
+        // Spawns a helth check service in the background to continuously check the health of the L2 and builder clients
         let health_handle = HealthHandle {
             probes: probes.clone(),
             builder_client: Arc::new(builder_client.clone()),
@@ -150,7 +151,7 @@ impl RollupBoostServer {
             health_check_interval,
         }
         .spawn();
-        // Spawn a thread for the continuous health check on the builder
+
         Self {
             l2_client: Arc::new(l2_client),
             builder_client: Arc::new(builder_client),

--- a/src/server.rs
+++ b/src/server.rs
@@ -145,7 +145,6 @@ impl RollupBoostServer {
         health_check_interval: u64,
         max_unsafe_interval: u64,
     ) -> Self {
-        // Spawns a helth check service in the background to continuously check the health of the L2 and builder clients
         let health_handle = HealthHandle {
             probes: probes.clone(),
             builder_client: Arc::new(builder_client.clone()),

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,3 +1,4 @@
+use crate::HealthHandle;
 use crate::client::rpc::RpcClient;
 use crate::debug_api::DebugServer;
 use crate::probe::{Health, Probes};
@@ -21,7 +22,7 @@ use op_alloy_rpc_types_engine::{
     OpPayloadAttributes,
 };
 use serde::{Deserialize, Serialize};
-
+use tokio::task::JoinHandle;
 use tracing::{debug, info, instrument};
 
 use jsonrpsee::proc_macros::rpc;
@@ -123,12 +124,12 @@ impl ExecutionMode {
     }
 }
 
-#[derive(Clone)]
 pub struct RollupBoostServer {
     pub l2_client: Arc<RpcClient>,
     pub builder_client: Arc<RpcClient>,
     pub boost_sync: bool,
     pub payload_trace_context: Arc<PayloadTraceContext>,
+    health_handle: JoinHandle<()>,
     execution_mode: Arc<Mutex<ExecutionMode>>,
     probes: Arc<Probes>,
 }
@@ -140,7 +141,16 @@ impl RollupBoostServer {
         boost_sync: bool,
         initial_execution_mode: ExecutionMode,
         probes: Arc<Probes>,
+        health_check_interval: u64,
     ) -> Self {
+        let health_handle = HealthHandle {
+            probes: probes.clone(),
+            builder_client: Arc::new(builder_client.clone()),
+            l2_client: Arc::new(l2_client.clone()),
+            health_check_interval,
+        }
+        .spawn();
+        // Spawn a thread for the continuous health check on the builder
         Self {
             l2_client: Arc::new(l2_client),
             builder_client: Arc::new(builder_client),
@@ -148,6 +158,7 @@ impl RollupBoostServer {
             payload_trace_context: Arc::new(PayloadTraceContext::new()),
             execution_mode: Arc::new(Mutex::new(initial_execution_mode)),
             probes,
+            health_handle,
         }
     }
 
@@ -160,6 +171,10 @@ impl RollupBoostServer {
     pub fn execution_mode(&self) -> ExecutionMode {
         *self.execution_mode.lock()
     }
+
+    pub fn health_handle(&self) -> &JoinHandle<()> {
+        &self.health_handle
+    }
 }
 
 impl TryInto<RpcModule<()>> for RollupBoostServer {
@@ -167,7 +182,7 @@ impl TryInto<RpcModule<()>> for RollupBoostServer {
 
     fn try_into(self) -> Result<RpcModule<()>, Self::Error> {
         let mut module: RpcModule<()> = RpcModule::new(());
-        module.merge(EngineApiServer::into_rpc(self.clone()))?;
+        module.merge(EngineApiServer::into_rpc(self))?;
 
         for method in module.method_names() {
             info!(?method, "method registered");
@@ -203,22 +218,22 @@ impl PayloadSource {
     }
 }
 
-#[rpc(server, client, namespace = "engine")]
+#[rpc(server, client)]
 pub trait EngineApi {
-    #[method(name = "forkchoiceUpdatedV3")]
+    #[method(name = "engine_forkchoiceUpdatedV3")]
     async fn fork_choice_updated_v3(
         &self,
         fork_choice_state: ForkchoiceState,
         payload_attributes: Option<OpPayloadAttributes>,
     ) -> RpcResult<ForkchoiceUpdated>;
 
-    #[method(name = "getPayloadV3")]
+    #[method(name = "engine_getPayloadV3")]
     async fn get_payload_v3(
         &self,
         payload_id: PayloadId,
     ) -> RpcResult<OpExecutionPayloadEnvelopeV3>;
 
-    #[method(name = "newPayloadV3")]
+    #[method(name = "engine_newPayloadV3")]
     async fn new_payload_v3(
         &self,
         payload: ExecutionPayloadV3,
@@ -226,13 +241,13 @@ pub trait EngineApi {
         parent_beacon_block_root: B256,
     ) -> RpcResult<PayloadStatus>;
 
-    #[method(name = "getPayloadV4")]
+    #[method(name = "engine_getPayloadV4")]
     async fn get_payload_v4(
         &self,
         payload_id: PayloadId,
     ) -> RpcResult<OpExecutionPayloadEnvelopeV4>;
 
-    #[method(name = "newPayloadV4")]
+    #[method(name = "engine_newPayloadV4")]
     async fn new_payload_v4(
         &self,
         payload: OpExecutionPayloadV4,
@@ -240,6 +255,9 @@ pub trait EngineApi {
         parent_beacon_block_root: B256,
         execution_requests: Vec<Bytes>,
     ) -> RpcResult<PayloadStatus>;
+
+    #[method(name = "eth_getBlockNumber")]
+    async fn get_block_number(&self) -> RpcResult<u64>;
 }
 
 #[async_trait]
@@ -409,6 +427,11 @@ impl EngineApiServer for RollupBoostServer {
             execution_requests,
         }))
         .await
+    }
+
+    async fn get_block_number(&self) -> RpcResult<u64> {
+        info!("received get_block_number");
+        Ok(self.l2_client.get_block_number().await?)
     }
 }
 
@@ -759,6 +782,7 @@ mod tests {
                 boost_sync,
                 ExecutionMode::Enabled,
                 probes,
+                10,
             );
 
             let module: RpcModule<()> = rollup_boost.try_into().unwrap();

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,7 +2,7 @@ use crate::HealthHandle;
 use crate::client::rpc::RpcClient;
 use crate::debug_api::DebugServer;
 use crate::probe::{Health, Probes};
-use alloy_primitives::{B256, Bytes};
+use alloy_primitives::{B256, Bytes, U256};
 use metrics::counter;
 use moka::sync::Cache;
 use opentelemetry::trace::SpanKind;
@@ -256,8 +256,8 @@ pub trait EngineApi {
         execution_requests: Vec<Bytes>,
     ) -> RpcResult<PayloadStatus>;
 
-    #[method(name = "eth_getBlockNumber")]
-    async fn get_block_number(&self) -> RpcResult<u64>;
+    #[method(name = "eth_blockNumber")]
+    async fn block_number(&self) -> RpcResult<U256>;
 }
 
 #[async_trait]
@@ -429,9 +429,8 @@ impl EngineApiServer for RollupBoostServer {
         .await
     }
 
-    async fn get_block_number(&self) -> RpcResult<u64> {
-        info!("received get_block_number");
-        Ok(self.l2_client.get_block_number().await?)
+    async fn block_number(&self) -> RpcResult<U256> {
+        Ok(self.l2_client.block_number().await?)
     }
 }
 


### PR DESCRIPTION
Spawns a Health Service in the background to continuously check that the builder is in sync with the l2 client, and both clients are available.
- If the builder is out of sync (or unresponsive) we set rollup-boost to the `PartialContent` health status. 
- If the l2 client is unresponsive we set rollup-boost to the `ServiceUnavailable` health status.
- If the builder, and l2 block height match we set rollup-boost to the `Healthy` status